### PR TITLE
enable tip note in comments if tip command came first

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ On supported subreddits, you can send a tip like this:
 
     !ban 1 This is great!
 
-This will tip a redditor 1 Banano. !bam <amount> must be the first thing in your message OR the last thing. Such, this is also a valid tip:
+This will tip a redditor 1 Banano and send "This is great!" along with your Reddit username as a tip note. !bam <amount> must be the first thing in your message OR the last thing. Such, this is also a valid tip, but will not send a tip note:
 
     This is great! !ban 1
 

--- a/src/comment_functions.py
+++ b/src/comment_functions.py
@@ -100,6 +100,10 @@ def send_from_comment(message):
     ):
         parsed_text = parsed_text[-2:]
 
+    # save comment as tip note if tip command came first
+    tip_note = ' '.join(parsed_text[2:])
+    tip_note = '\n\n' + message.author + " included the following tip note: " + tip_note if tip_note else ""
+
     # before we can do anything, check the subreddit status for generating the response
     response["subreddit"] = str(message.subreddit).lower()
     try:
@@ -214,6 +218,7 @@ def send_from_comment(message):
                 recipient_info["address"],
                 recipient_info["address"],
             )
+            + tip_note
             + text.COMMENT_FOOTER
         )
         send_pm(recipient_info["username"], subject, message_text)
@@ -230,6 +235,7 @@ def send_from_comment(message):
                     from_raw(receiving_new_balance),
                     response["hash"],
                 )
+                + tip_note
                 + text.COMMENT_FOOTER
             )
             send_pm(recipient_info["username"], subject, message_text)


### PR DESCRIPTION
This was requested by /u/MotherTurf during a recent livestream where folks wanted to pay to request songs with BAN but had to use Venmo instead because of the ability to attach a note.